### PR TITLE
Micro-optimize dll imports and fixup the resolver

### DIFF
--- a/sources/Interop/Libc/Libc.cs
+++ b/sources/Interop/Libc/Libc.cs
@@ -1,0 +1,28 @@
+// Copyright © Tanner Gooding and Contributors. Licensed under the MIT License (MIT). See License.md in the repository root for more information.
+
+using System;
+using System.Reflection;
+using System.Runtime.InteropServices;
+
+namespace TerraFX.Interop
+{
+    public static unsafe partial class Libc
+    {
+        private const string libraryPath = "libc";
+
+        static Libc()
+        {
+            NativeLibrary.SetDllImportResolver(Assembly.GetExecutingAssembly(), ResolveLibrary);
+        }
+
+        private static IntPtr ResolveLibrary(string libraryName, Assembly assembly, DllImportSearchPath? searchPath)
+        {
+            if (!NativeLibrary.TryLoad("libc.so", assembly, searchPath, out var nativeLibrary))
+            {
+                nativeLibrary = NativeLibrary.Load("libc.so.6", assembly, searchPath);
+            }
+
+            return nativeLibrary;
+        }
+    }
+}

--- a/sources/Interop/Libc/NativeTypeNameAttribute.cs
+++ b/sources/Interop/Libc/NativeTypeNameAttribute.cs
@@ -8,7 +8,7 @@ namespace TerraFX.Interop
     /// <summary>Defines the type of a member as it was used in the native signature.</summary>
     [AttributeUsage(AttributeTargets.Property | AttributeTargets.Field | AttributeTargets.Parameter | AttributeTargets.ReturnValue, AllowMultiple = false, Inherited = true)]
     [Conditional("DEBUG")]
-    public sealed class NativeTypeNameAttribute : Attribute
+    internal sealed class NativeTypeNameAttribute : Attribute
     {
         private readonly string _name;
 

--- a/sources/Interop/Libc/time/Libc.cs
+++ b/sources/Interop/Libc/time/Libc.cs
@@ -11,13 +11,13 @@ namespace TerraFX.Interop
     {
         private const string libraryPath = "c";
 
-        [DllImport(libraryPath, EntryPoint = "clock_getres", CallingConvention = CallingConvention.Cdecl)]
+        [DllImport(libraryPath, EntryPoint = "clock_getres", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern int clock_getres([NativeTypeName("clockid_t")] int clock_id, [NativeTypeName("struct timespec *")] timespec* res);
 
-        [DllImport(libraryPath, EntryPoint = "clock_gettime", CallingConvention = CallingConvention.Cdecl)]
+        [DllImport(libraryPath, EntryPoint = "clock_gettime", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern int clock_gettime([NativeTypeName("clockid_t")] int clock_id, [NativeTypeName("struct timespec *")] timespec* tp);
 
-        [DllImport(libraryPath, EntryPoint = "clock_settime", CallingConvention = CallingConvention.Cdecl)]
+        [DllImport(libraryPath, EntryPoint = "clock_settime", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern int clock_settime([NativeTypeName("clockid_t")] int clock_id, [NativeTypeName("struct timespec *")] timespec* tp);
     }
 }

--- a/sources/Interop/Libc/time/Libc.cs
+++ b/sources/Interop/Libc/time/Libc.cs
@@ -9,8 +9,6 @@ namespace TerraFX.Interop
 {
     public static unsafe partial class Libc
     {
-        private const string libraryPath = "c";
-
         [DllImport(libraryPath, EntryPoint = "clock_getres", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern int clock_getres([NativeTypeName("clockid_t")] int clock_id, [NativeTypeName("struct timespec *")] timespec* res);
 


### PR DESCRIPTION
This specifies `ExactSpelling=true` for the `DllImport` definitions and adds a `DllImportResolver`.