### PR TITLE
Adding the ability for users to hook the DllImportResolver

### DIFF
--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -19,8 +19,8 @@
 
   <!-- Package versions for package references across all projects -->
   <ItemGroup>
-    <PackageReference Update="Microsoft.Net.Compilers.Toolset" Version="3.4.0" />
-    <PackageReference Update="Microsoft.NET.Test.Sdk" Version="16.4.0" />
+    <PackageReference Update="Microsoft.Net.Compilers.Toolset" Version="3.5.0-beta1-final" />
+    <PackageReference Update="Microsoft.NET.Test.Sdk" Version="16.5.0-preview-20191115-01" />
     <PackageReference Update="Microsoft.SourceLink.GitHub" Version="1.0.0" />
     <PackageReference Update="NUnit" Version="3.12.0" />
     <PackageReference Update="NUnit3TestAdapter" Version="3.15.1" />

--- a/sources/Interop/Libc/NativeTypeNameAttribute.cs
+++ b/sources/Interop/Libc/NativeTypeNameAttribute.cs
@@ -6,7 +6,7 @@ using System.Diagnostics;
 namespace TerraFX.Interop
 {
     /// <summary>Defines the type of a member as it was used in the native signature.</summary>
-    [AttributeUsage(AttributeTargets.Property | AttributeTargets.Field | AttributeTargets.Parameter | AttributeTargets.ReturnValue, AllowMultiple = false, Inherited = true)]
+    [AttributeUsage(AttributeTargets.Enum | AttributeTargets.Property | AttributeTargets.Field | AttributeTargets.Parameter | AttributeTargets.ReturnValue, AllowMultiple = false, Inherited = true)]
     [Conditional("DEBUG")]
     internal sealed class NativeTypeNameAttribute : Attribute
     {

--- a/sources/Interop/Libc/time/Libc.cs
+++ b/sources/Interop/Libc/time/Libc.cs
@@ -9,13 +9,13 @@ namespace TerraFX.Interop
 {
     public static unsafe partial class Libc
     {
-        [DllImport(libraryPath, EntryPoint = "clock_getres", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, CallingConvention = CallingConvention.Cdecl, EntryPoint = "clock_getres", ExactSpelling = true, SetLastError = true)]
         public static extern int clock_getres([NativeTypeName("clockid_t")] int clock_id, [NativeTypeName("struct timespec *")] timespec* res);
 
-        [DllImport(libraryPath, EntryPoint = "clock_gettime", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, CallingConvention = CallingConvention.Cdecl, EntryPoint = "clock_gettime", ExactSpelling = true, SetLastError = true)]
         public static extern int clock_gettime([NativeTypeName("clockid_t")] int clock_id, [NativeTypeName("struct timespec *")] timespec* tp);
 
-        [DllImport(libraryPath, EntryPoint = "clock_settime", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, CallingConvention = CallingConvention.Cdecl, EntryPoint = "clock_settime", ExactSpelling = true, SetLastError = true)]
         public static extern int clock_settime([NativeTypeName("clockid_t")] int clock_id, [NativeTypeName("struct timespec *")] timespec* tp);
     }
 }


### PR DESCRIPTION
This updates the package dependencies to the VS 16.5.0 Preview 1 equivalents and adds the capability for users to hook the DllImportResolver.